### PR TITLE
Fix unescaped double quotes in sql_database_agent.ipynb.

### DIFF
--- a/content/chapter_6/sql_database_agent.ipynb
+++ b/content/chapter_6/sql_database_agent.ipynb
@@ -248,7 +248,7 @@
     "    toolkit=toolkit,\n",
     "    verbose=True,\n",
     "    agent_type=AgentType.OPENAI_FUNCTIONS,\n",
-    "    prefix=SQL_PREFIX.format(dialect="SQLite", top_k=100),\n",
+    "    prefix=SQL_PREFIX.format(dialect=\"SQLite\", top_k=100),\n",
     ")"
    ]
   },


### PR DESCRIPTION
This refers to #22 

The file `content/chapter_6/sql_database_agent.ipynb` cannot be properly shown on GitHub. The error was `The Notebook Does Not Appear to Be Valid JSON`.

<img width="1183" alt="Image" src="https://github.com/user-attachments/assets/0f9bb1b1-b697-4bbd-8767-50aed36b69a9" />

It seems that a line of the notebook would need to escape `"` with `\`. After this fix the notebook becomes valid one.

<img width="1163" alt="Screenshot 2025-05-14 at 1 38 41 PM" src="https://github.com/user-attachments/assets/2a154c95-3124-4521-84ba-6f088e0de589" />
